### PR TITLE
Add WA_CREEP setting to filter bad negative watts

### DIFF
--- a/esphome/components/bl0939addr/bl0939.cpp
+++ b/esphome/components/bl0939addr/bl0939.cpp
@@ -21,6 +21,7 @@ static const uint8_t BL0939_REG_MODE = 0x18;
 static const uint8_t BL0939_REG_SOFT_RESET = 0x19;
 static const uint8_t BL0939_REG_USR_WRPROT = 0x1A;
 static const uint8_t BL0939_REG_TPS_CTRL = 0x1B;
+static const uint8_t BL0939_REG_WA_CREEP = 0x17;
 
 static Mutex bl0939_global_lock;
 
@@ -30,6 +31,66 @@ uint8_t BL0939::write_command() {
 
 uint8_t BL0939::read_command() {
   return BL0939_READ_COMMAND | this->address_;
+}
+
+uint8_t bl0939_write_checksum(uint8_t cmd, uint8_t reg, uint8_t d0, uint8_t d1, uint8_t d2) {
+  uint8_t sum = cmd;
+  sum += reg;
+  sum += d0;
+  sum += d1;
+  sum += d2;
+  sum ^= 0xFF;
+  return sum;
+}
+
+void bl0939_write_reg24(esphome::bl0939::BL0939 *dev, uint8_t reg, uint32_t value24) {
+  // BL0939 uses little-endian payload ordering in these init frames:
+  // examples in your code: reg MODE 0x18 with 0x00,0x10,0x00 == 0x001000
+  uint8_t d0 = (value24 >> 16) & 0xFF;  // H
+  uint8_t d1 = (value24 >> 8) & 0xFF;   // M
+  uint8_t d2 = (value24 >> 0) & 0xFF;   // L
+
+  uint8_t cmd = dev->write_command();
+  uint8_t frame[6] = {cmd, reg, d0, d1, d2, bl0939_write_checksum(cmd, reg, d0, d1, d2)};
+  dev->write_array(frame, 6);
+  delay(1);
+}
+
+
+static uint8_t bl0939_checksum(uint8_t cmd, uint8_t addr, uint8_t dl, uint8_t dm, uint8_t dh) {
+  uint8_t sum = cmd + addr + dl + dm + dh;
+  return sum ^ 0xFF;
+}
+
+bool BL0939::read_reg24_(uint8_t reg, uint32_t *out) {
+  // TX: [READCMD][REG]
+  this->write_byte(this->read_command());
+  this->write_byte(reg);
+
+  // datasheet: device replies with 3 data bytes + checksum (low..high) :contentReference[oaicite:8]{index=8}
+  uint8_t dl=0, dm=0, dh=0, cs=0;
+  if (!this->read_byte(&dl)) return false;
+  if (!this->read_byte(&dm)) return false;
+  if (!this->read_byte(&dh)) return false;
+  if (!this->read_byte(&cs)) return false;
+
+  uint8_t exp = bl0939_checksum(this->read_command(), reg, dl, dm, dh);
+  if (cs != exp) return false;
+
+  *out = ((uint32_t)dh << 16) | ((uint32_t)dm << 8) | dl;
+  return true;
+}
+
+bool BL0939::write_reg24_(uint8_t reg, uint32_t value24) {
+  uint8_t dl = (value24 >> 0) & 0xFF;
+  uint8_t dm = (value24 >> 8) & 0xFF;
+  uint8_t dh = (value24 >> 16) & 0xFF;
+
+  uint8_t cmd = this->write_command();
+  uint8_t frame[6] = {cmd, reg, dl, dm, dh, bl0939_checksum(cmd, reg, dl, dm, dh)};
+  this->write_array(frame, 6);
+  delay(2);
+  return true;
 }
 
 void BL0939::loop() {
@@ -127,6 +188,26 @@ void BL0939::setup() {
     this->write_array(i, 6);
     delay(1);
   }
+
+  // --- Anti-creep threshold ---
+  // Default is 0x0B
+  // uint32_t wc = this->wa_creep_;
+  // bl0939_write_reg24(this, BL0939_REG_WA_CREEP, (wc << 16) | (wc << 8) | wc);
+  //bl0939_write_reg24(this, BL0939_REG_WA_CREEP, ((uint32_t)this->wa_creep_) << 16);
+
+  // unlock
+  this->write_reg24_(BL0939_REG_USR_WRPROT, 0x000055);  // L=0x55, reszta 0 :contentReference[oaicite:9]{index=9}
+  delay(2);
+
+  // write WA_CREEP
+  this->write_reg24_(BL0939_REG_WA_CREEP, (uint32_t)(this->wa_creep_ & 0xFF));
+  delay(2);
+
+  // readback
+  uint32_t rb = 0;
+  bool ok = this->read_reg24_(BL0939_REG_WA_CREEP, &rb);
+  ESP_LOGI(TAG, "WA_CREEP write=0x%02X readback=%s 0x%06X", this->wa_creep_, ok ? "OK" : "FAIL", rb);
+
   this->flush();
 
   bl0939_global_lock.unlock();

--- a/esphome/components/bl0939addr/bl0939.h
+++ b/esphome/components/bl0939addr/bl0939.h
@@ -62,6 +62,10 @@ class BL0939 : public PollingComponent, public uart::UARTDevice {
   void set_voltage_reference(float voltage_reference) { voltage_reference_ = voltage_reference; }
   void set_power_reference(float power_reference) { power_reference_ = power_reference; }
   void set_energy_reference(float energy_reference) { energy_reference_ = energy_reference; }
+  void set_wa_creep(uint8_t v) { wa_creep_ = v; }
+  uint8_t wa_creep_{0x0B};
+  bool read_reg24_(uint8_t reg, uint32_t *out);
+  bool write_reg24_(uint8_t reg, uint32_t value24);
 
   void loop() override;
 

--- a/esphome/components/bl0939addr/sensor.py
+++ b/esphome/components/bl0939addr/sensor.py
@@ -30,6 +30,7 @@ CONF_CURRENT_REFERENCE = "current_reference"
 CONF_VOLTAGE_REFERENCE = "voltage_reference"
 CONF_POWER_REFERENCE = "power_reference"
 CONF_ENERGY_REFERENCE = "energy_reference"
+CONF_WA_CREEP = "wa_creep"
 
 
 # https://datasheet.lcsc.com/lcsc/2108071830_BL-Shanghai-Belling-BL0939_C2841044.pdf
@@ -102,6 +103,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_VOLTAGE_REFERENCE, default=default_voltage_reference): cv.float_,
             cv.Optional(CONF_POWER_REFERENCE, default=default_power_reference): cv.float_,
             cv.Optional(CONF_ENERGY_REFERENCE, default=default_energy_reference): cv.float_,
+            cv.Optional(CONF_WA_CREEP, default=0x0B): cv.uint8_t,
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -150,3 +152,5 @@ async def to_code(config):
         cg.add(var.set_power_reference(power_reference_config))
     if energy_reference_config := config.get(CONF_ENERGY_REFERENCE):
         cg.add(var.set_energy_reference(energy_reference_config))
+    if wa_creep_config := config.get(CONF_WA_CREEP):
+        cg.add(var.set_wa_creep(wa_creep_config))

--- a/esphome/power-meter-9000.yaml
+++ b/esphome/power-meter-9000.yaml
@@ -66,6 +66,7 @@ sensor:
     voltage_reference: 16740.165
     power_reference: 1147.908
     energy_reference: 9852.572
+    wa_creep: 0x5E
 
   - platform: bl0939addr
     id: ch1
@@ -91,6 +92,7 @@ sensor:
     voltage_reference: 16740.165
     power_reference: 1147.908
     energy_reference: 9852.572
+    wa_creep: 0x5E
   
   - platform: bl0939addr
     id: ch2
@@ -116,6 +118,7 @@ sensor:
     voltage_reference: 16740.165
     power_reference: 1147.908
     energy_reference: 9852.572
+    wa_creep: 0x5E
 
   - platform: bl0939addr
     id: ch3
@@ -141,6 +144,7 @@ sensor:
     voltage_reference: 16740.165
     power_reference: 1147.908
     energy_reference: 9852.572
+    wa_creep: 0x5E
 
 switch:
   - platform: gpio


### PR DESCRIPTION
Clamp |P| below the WA_CREEP threshold to 0 W. Fixes spurious -1 W readings reported on an idle circuit with no load connected (ADC offset/noise near zero).